### PR TITLE
Implement atomic database saves & refine data operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,10 @@ go 1.24
 require github.com/spf13/cobra v1.9.1
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,17 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -15,17 +15,18 @@ type DataStore interface {
 	Open(filePath string) (*[]byte, error)
 	Decode(data *[]byte) error
 	Encode(entries []*Directory) ([]byte, error)
-	Add(path string) error
-	AddAndSave(path string) error
+	Add(path string) error // Adds to memory only
+	AddAndSave(path string) error // Adds and persists
 	Get(path string) (*Directory, error)
-	All() ([]Directory, error)
+	All() ([]*Directory, error)
 	Save() error
 	Dedup() error
 	SortByDirectory() error
 	AddUpdate(dir string) error
-	Remove(dir *Directory) error
+	Remove(path string) error // Takes string path for consistency
 	DetermineFilthy() error
-	SwapRemove(idx int) error
+	SwapRemoveIDX(idx int) error // Remove by index, O(1)
+	SwapRemove(path string) error // Remove by path, O(1) if found
 }
 
 type DirectoryManager struct {
@@ -36,7 +37,7 @@ type DirectoryManager struct {
 	mu       sync.RWMutex
 }
 
-// NewDirectoryManager creates a new GobStore instance by accessing  reading in data from the given filepath.
+// NewDirectoryManager creates a new GobStore instance by accessing reading in data from the given filepath.
 func NewDirectoryManagerWithPath(filePath string) (*DirectoryManager, error) {
 	dm := &DirectoryManager{
 		FilePath: filePath,
@@ -48,8 +49,7 @@ func NewDirectoryManagerWithPath(filePath string) (*DirectoryManager, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	dm.raw = *rawgob
+	dm.raw = *rawgob // Store the raw bytes for initial state
 
 	err = dm.Decode(rawgob)
 	if err != nil {
@@ -61,93 +61,78 @@ func NewDirectoryManagerWithPath(filePath string) (*DirectoryManager, error) {
 
 func NewDirectoryManager() (*DirectoryManager, error) {
 	filePath := os.Getenv("GOZELLE_DATA_DIR")
-
-	dm := &DirectoryManager{
-		FilePath: filePath,
-		Entries:  []*Directory{},
-		Dirty:    false,
+	if filePath == "" {
+		// Fallback or error handling if GOZELLE_DATA_DIR is not set
+		// For now, let's assume it's set by core.SetConfig() before this is called.
+		// If not, this could lead to issues. Consider returning an error or having a default.
+		// However, core.SetConfig() ensures it's set.
 	}
-
-	rawgob, err := dm.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	dm.raw = *rawgob
-
-	err = dm.Decode(rawgob)
-	if err != nil {
-		return nil, err
-	}
-
-	return dm, nil
+	return NewDirectoryManagerWithPath(filePath)
 }
 
 func (dm *DirectoryManager) Open(filePath string) (*[]byte, error) {
-	// check if the file exists
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		// check directory exists
 		dir := filepath.Dir(filePath)
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			log.Println("Error creating directory:", filePath)
+			log.Printf("[ERROR] Open: failed to create directories for %s: %v", dir, err)
 			return nil, fmt.Errorf("failed to create directories: %w", err)
 		}
-
-		// create an empty file
 		if err := os.WriteFile(filePath, []byte{}, 0644); err != nil {
+			log.Printf("[ERROR] Open: failed to create empty file %s: %v", filePath, err)
 			return nil, fmt.Errorf("failed to create file: %w", err)
 		}
+		log.Printf("[DEBUG] Open: Created new empty db file at %s", filePath)
+		return &[]byte{}, nil // Return empty byte slice for new file
 	}
 
-	// read the file's contents
 	data, err := os.ReadFile(filePath)
 	if err != nil {
+		log.Printf("[ERROR] Open: failed to read file %s: %v", filePath, err)
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
-
 	return &data, nil
 }
 
 // Decode decodes the data from the byte slice into the DirectoryManager's Entries field.
 func (dm *DirectoryManager) Decode(data *[]byte) error {
-	dm.mu.RLock()
-	defer dm.mu.RUnlock()
+	// dm.mu.RLock() // Decode is usually called during initialization before concurrent access
+	// defer dm.mu.RUnlock() // or if called later, lock would be needed. Assuming init context for now.
 
 	if data == nil || len(*data) == 0 {
 		dm.Entries = []*Directory{}
-		// log.Println("No data found, initializing empty directory manager.")
+		log.Println("[DEBUG] Decode: No data found, initializing empty directory manager.")
 		return nil
 	}
 
 	decoder := gob.NewDecoder(bytes.NewReader(*data))
-
-	// decode datainto directory slice
 	var decodedEntries []*Directory
 	err := decoder.Decode(&decodedEntries)
 	if err != nil {
-		return errors.New("failed to decode data: " + err.Error())
+		log.Printf("[ERROR] Decode: failed to decode data: %v", err)
+		return fmt.Errorf("failed to decode data: %w", err)
 	}
-
 	dm.Entries = decodedEntries
-
-	// log.Println("Decoded entries:", dm.Entries)
+	log.Printf("[DEBUG] Decode: Decoded %d entries.", len(dm.Entries))
 	return nil
 }
 
 // Encode encodes the DirectoryManager's Entries field into a byte slice.
 func (dm *DirectoryManager) Encode(entries []*Directory) ([]byte, error) {
+	// dm.mu.RLock() // Encode reads Entries, so if called concurrently, RLock is needed.
+	// defer dm.mu.RUnlock() // Assuming lock is managed by caller (e.g., saveInternal)
 	var buf bytes.Buffer
 	encoder := gob.NewEncoder(&buf)
-
-	// Encode the slice of Directory pointers into the buffer
 	err := encoder.Encode(entries)
 	if err != nil {
-		return nil, errors.New("failed to encode Entries: " + err.Error())
+		log.Printf("[ERROR] Encode: failed to encode Entries: %v", err)
+		return nil, fmt.Errorf("failed to encode Entries: %w", err)
 	}
-
 	return buf.Bytes(), nil
 }
 
+// Add adds a new directory to the directory manager in memory only.
+// It marks the manager as Dirty but does NOT persist changes to disk.
+// Call Save() to persist or use AddAndSave for immediate persistence.
 // Add adds a new directory to the directory manager in memory only.
 // It marks the manager as Dirty but does NOT persist changes to disk.
 // Call Save() to persist or use AddAndSave for immediate persistence.
@@ -155,7 +140,7 @@ func (dm *DirectoryManager) Add(path string) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
-	log.Printf("[DEBUG] Add: adding path %s", path)
+	log.Printf("[DEBUG] Add: adding path '%s' to memory", path)
 	dir := NewDirectory(path)
 	dm.Entries = append(dm.Entries, dir)
 	dm.Dirty = true
@@ -164,16 +149,17 @@ func (dm *DirectoryManager) Add(path string) error {
 
 // AddAndSave adds a new directory and immediately saves the directory manager to disk.
 // This is the legacy behavior of Add prior to v0.2.0.
+// AddAndSave adds a new directory and immediately saves the directory manager to disk.
 func (dm *DirectoryManager) AddAndSave(path string) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
-	log.Printf("[DEBUG] AddAndSave: adding path %s", path)
+	log.Printf("[DEBUG] AddAndSave: adding path '%s' and saving", path)
 	dir := NewDirectory(path)
 	dm.Entries = append(dm.Entries, dir)
-	dm.Dirty = true
+	dm.Dirty = true // Mark dirty before saveInternal checks it
 	if err := dm.saveInternal(); err != nil {
-		return fmt.Errorf("failed to save directory manager: %w", err)
+		return fmt.Errorf("AddAndSave: %w", err)
 	}
 	return nil
 }
@@ -194,11 +180,14 @@ func (dm *DirectoryManager) Get(path string) (*Directory, error) {
 func (dm *DirectoryManager) All() ([]*Directory, error) {
 	dm.mu.RLock()
 	defer dm.mu.RUnlock()
-	if len(dm.Entries) > 0 {
-		return dm.Entries, nil
+	if len(dm.Entries) == 0 {
+		// It's not an error to have no entries, just return an empty slice.
+		return []*Directory{}, nil
 	}
-	// if no entries are found, return an empty slice
-	return []*Directory{}, fmt.Errorf("no directories found")
+	// Return a copy to prevent external modification of the internal slice
+	entriesCopy := make([]*Directory, len(dm.Entries))
+	copy(entriesCopy, dm.Entries)
+	return entriesCopy, nil
 }
 
 // saves the directory manager to a file
@@ -209,42 +198,40 @@ func (dm *DirectoryManager) Save() error {
 	return dm.saveInternal()
 }
 
-// saveInternal is the actual save logic, assumes lock is already held
+// saveInternal is the actual save logic, assumes lock is already held by the caller.
 func (dm *DirectoryManager) saveInternal() error {
 	if !dm.Dirty {
 		log.Println("[DEBUG] saveInternal: Not dirty, skipping save.")
 		return nil
 	}
 	log.Println("[DEBUG] saveInternal: Encoding data.")
-	encodedData, err := dm.Encode(dm.Entries)
+	encodedData, err := dm.Encode(dm.Entries) // Encode reads dm.Entries
 	if err != nil {
-		log.Printf("[DEBUG] saveInternal: failed to encode directory manager: %v", err)
-		return fmt.Errorf("failed to encode directory manager: %w", err)
+		// Error already logged in Encode
+		return fmt.Errorf("saveInternal encoding: %w", err)
 	}
 
 	tempFilePath := dm.FilePath + ".tmp"
-	log.Println("[DEBUG] saveInternal: Writing to temporary file", tempFilePath)
+	log.Printf("[DEBUG] saveInternal: Writing %d bytes to temporary file %s", len(encodedData), tempFilePath)
 	err = os.WriteFile(tempFilePath, encodedData, 0644)
 	if err != nil {
-		log.Printf("[DEBUG] saveInternal: failed to write to temp file: %v", err)
-		_ = os.Remove(tempFilePath) // Clean up temp file if it was created
+		log.Printf("[ERROR] saveInternal: failed to write to temp file %s: %v", tempFilePath, err)
+		// Attempt to clean up the temporary file if rename fails, even if it's partially written
+		_ = os.Remove(tempFilePath)
 		return fmt.Errorf("failed to write to temporary file %s: %w", tempFilePath, err)
 	}
 
-	log.Println("[DEBUG] saveInternal: Renaming temporary file to", dm.FilePath)
+	log.Printf("[DEBUG] saveInternal: Renaming temporary file %s to %s", tempFilePath, dm.FilePath)
 	err = os.Rename(tempFilePath, dm.FilePath)
 	if err != nil {
-		log.Printf("[DEBUG] saveInternal: failed to rename temp file: %v", err)
-		_ = os.Remove(tempFilePath)
+		log.Printf("[ERROR] saveInternal: failed to rename temp file %s to %s: %v", tempFilePath, dm.FilePath, err)
+		_ = os.Remove(tempFilePath) // Clean up temp file if rename fails
 		return fmt.Errorf("failed to rename temporary file %s to %s: %w", tempFilePath, dm.FilePath, err)
 	}
-
 	dm.Dirty = false
-	log.Println("[DEBUG] saveInternal: Save successful.")
-	// update the raw data after saving
-	dm.raw = make([]byte, len(encodedData))
+	dm.raw = make([]byte, len(encodedData)) // Update raw with the successfully saved data
 	copy(dm.raw, encodedData)
-
+	log.Println("[DEBUG] saveInternal: Save successful.")
 	return nil
 }
 
@@ -252,114 +239,178 @@ func (dm *DirectoryManager) saveInternal() error {
 func (dm *DirectoryManager) Dedup() error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
-	log.Println("[DEBUG] Dedup: acquiring lock")
-	dm.SortByDirectory()
-	for i := 0; i < len(dm.Entries)-1; {
-		if dm.Entries[i].Path == dm.Entries[i+1].Path {
-			dm.Entries[i].Score += dm.Entries[i+1].Score
-			if dm.Entries[i].LastVisit < dm.Entries[i+1].LastVisit {
-				dm.Entries[i].LastVisit = dm.Entries[i+1].LastVisit
+	log.Println("[DEBUG] Dedup: Performing deduplication.")
+
+	if len(dm.Entries) < 2 {
+		log.Println("[DEBUG] Dedup: Not enough entries to dedup.")
+		return nil // Nothing to dedup
+	}
+	dm.SortByDirectory() // SortByDirectory doesn't lock, called under dm.mu
+
+	originalCount := len(dm.Entries)
+	newEntries := make([]*Directory, 0, len(dm.Entries))
+	if len(dm.Entries) > 0 {
+		newEntries = append(newEntries, dm.Entries[0])
+		for i := 1; i < len(dm.Entries); i++ {
+			lastAdded := newEntries[len(newEntries)-1]
+			current := dm.Entries[i]
+			if lastAdded.Path == current.Path {
+				lastAdded.Score += current.Score
+				if lastAdded.LastVisit < current.LastVisit {
+					lastAdded.LastVisit = current.LastVisit
+				}
+				dm.Dirty = true // Mark dirty if merging happened
+			} else {
+				newEntries = append(newEntries, current)
 			}
-			// remove duplicate entry
-			dm.RemoveIDX(i + 1)
-			if !dm.Dirty {
-				dm.Dirty = true
-			}
-			// don't increment i, check the new i+1 again
-		} else {
-			i++
 		}
 	}
-	// Optionally persist dedup changes immediately:
+	dm.Entries = newEntries
+
+	if originalCount != len(dm.Entries) {
+		dm.Dirty = true // Also dirty if count changed
+		log.Printf("[DEBUG] Dedup: Reduced entries from %d to %d.", originalCount, len(dm.Entries))
+	} else if dm.Dirty { // If only scores/visits updated
+		log.Println("[DEBUG] Dedup: Updated scores/visits for duplicate paths.")
+	} else {
+		log.Println("[DEBUG] Dedup: No duplicates found or changes made.")
+	}
+
+	// Decide if Dedup should save. If it made changes, it should probably save.
 	// if dm.Dirty {
-	//     return dm.saveInternal()
+	// 	log.Println("[DEBUG] Dedup: Changes made, saving.")
+	// 	return dm.saveInternal()
 	// }
 	return nil
 }
 
 // SortByDirectory sorts the directories in the directory manager by their path
 func (dm *DirectoryManager) SortByDirectory() error {
-	quickSort(dm.Entries, 0, len(dm.Entries)-1)
+	// This method operates on dm.Entries directly.
+	// It should be called when dm.mu is held if concurrent access is possible.
+	// It does not modify Dirty status by itself.
+	if len(dm.Entries) > 1 {
+		quickSort(dm.Entries, 0, len(dm.Entries)-1)
+	}
 	return nil
 }
 
 // AddUpdate adds a directory to the directory manager and immediately persists it to file.
 // This is equivalent to AddAndSave and is provided for API compatibility.
+// AddUpdate adds a directory to the directory manager and immediately persists it to file.
 func (dm *DirectoryManager) AddUpdate(dir string) error {
+	log.Printf("[DEBUG] AddUpdate: adding path '%s'", dir)
 	return dm.AddAndSave(dir)
 }
 
+// RemoveIDX removes an entry by index. Assumes lock is held by caller if needed
+// and caller handles Dirty status and saving.
 func (dm *DirectoryManager) RemoveIDX(idx int) error {
 	if idx < 0 || idx >= len(dm.Entries) {
-		return fmt.Errorf("index out of range: %d", idx)
+		return fmt.Errorf("RemoveIDX: index %d out of range for %d entries", idx, len(dm.Entries))
 	}
-
 	dm.Entries = append(dm.Entries[:idx], dm.Entries[idx+1:]...)
+	// dm.Dirty = true // Caller should set Dirty and save
 	return nil
 }
 
 // Remove removes a directory from the directory manager
-func (dm *DirectoryManager) Remove(dir string) error {
-	dm.SortByDirectory()
+// Remove searches for a directory by path and removes it if found.
+// Persists changes immediately.
+func (dm *DirectoryManager) Remove(path string) error {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	log.Printf("[DEBUG] Remove: Attempting to remove path '%s'", path)
 
-	idx := binarySearch(dm.Entries, dir)
+	dm.SortByDirectory() // Sort to use binarySearch
+	idx := binarySearch(dm.Entries, path)
 
 	if idx == -1 {
-		return fmt.Errorf("directory not found: %s", dir)
+		log.Printf("[DEBUG] Remove: Path '%s' not found.", path)
+		return fmt.Errorf("directory not found for removal: %s", path)
 	}
 
 	dm.Entries = append(dm.Entries[:idx], dm.Entries[idx+1:]...)
-	return nil
+	dm.Dirty = true
+	log.Printf("[DEBUG] Remove: Path '%s' removed, saving.", path)
+	return dm.saveInternal()
 }
 
 // DetermineFilthy checks if the directory manager is dirty
 func (dm *DirectoryManager) DetermineFilthy() error {
+	dm.mu.RLock() // Need RLock to safely call Encode and access dm.raw
+	defer dm.mu.RUnlock()
+
 	current, err := dm.Encode(dm.Entries)
 	if err != nil {
-		return fmt.Errorf("failed to encode directory manager: %w", err)
+		return fmt.Errorf("DetermineFilthy encoding: %w", err)
 	}
 	if bytes.Equal(current, dm.raw) {
-		dm.Dirty = false
-		return nil
+		// To be absolutely sure dm.Dirty is correct, we might reset it here.
+		// However, dm.Dirty should reflect if an operation *intended* to make a change.
+		// This check is more about whether the *current state* matches *last saved state*.
+		// For simplicity, let's not modify dm.Dirty here, just report.
+		// dm.Dirty = false
+		return nil // Not filthy if current encoding matches raw bytes of last save
 	}
-	dm.Dirty = true
-	return nil
+	// dm.Dirty = true // No, don't set it here. This function just checks.
+	return errors.New("DetermineFilthy: current state differs from last saved state (filthy)")
 }
 
 // SwapRemove removes a directory from the directory manager and updates the file
 // useful because it makes removal 0(1) instead of O(n)
+// SwapRemoveIDX removes a directory by index using O(1) swap and persists changes.
 func (dm *DirectoryManager) SwapRemoveIDX(idx int) error {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
-	log.Println("[DEBUG] SwapRemoveIDX: acquiring lock")
+	log.Printf("[DEBUG] SwapRemoveIDX: Attempting to remove index %d", idx)
 
 	if idx < 0 || idx >= len(dm.Entries) {
-		return fmt.Errorf("index out of range: %d", idx)
+		return fmt.Errorf("SwapRemoveIDX: index %d out of range for %d entries", idx, len(dm.Entries))
 	}
-	if idx == -1 {
-		return fmt.Errorf("directory not found")
-	}
-	// Swap the entry with the last entry and then remove the last entry
-	dm.Entries[idx], dm.Entries[len(dm.Entries)-1] = dm.Entries[len(dm.Entries)-1], dm.Entries[idx]
-	dm.Entries = dm.Entries[:len(dm.Entries)-1]
+
+	lastIdx := len(dm.Entries) - 1
+	dm.Entries[idx], dm.Entries[lastIdx] = dm.Entries[lastIdx], dm.Entries[idx]
+	dm.Entries = dm.Entries[:lastIdx]
 	dm.Dirty = true
+	log.Printf("[DEBUG] SwapRemoveIDX: Index %d removed, saving.", idx)
 	return dm.saveInternal()
 }
 
-func (dm *DirectoryManager) SwapRemove(dir string) error {
-	dm.SortByDirectory()
+// SwapRemove searches for a directory by path, then uses SwapRemoveIDX for O(1) removal if found.
+// Persists changes immediately.
+func (dm *DirectoryManager) SwapRemove(path string) error {
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	log.Printf("[DEBUG] SwapRemove: Attempting to remove path '%s'", path)
 
-	idx := binarySearch(dm.Entries, dir)
-
-	if idx == -1 {
-		return fmt.Errorf("directory not found: %s", dir)
+	// This makes SwapRemove O(N log N) or O(N) due to search, not O(1) unless path is pre-indexed.
+	// For true O(1) by path, a map[string]int would be needed to store indices.
+	// Current implementation: find index first.
+	idxToSwap := -1
+	for i, dir := range dm.Entries {
+		if dir.Path == path {
+			idxToSwap = i
+			break
+		}
 	}
 
-	// Swap the entry with the last entry and then remove the last entry
-	dm.Entries[idx], dm.Entries[len(dm.Entries)-1] = dm.Entries[len(dm.Entries)-1], dm.Entries[idx]
-	dm.Entries = dm.Entries[:len(dm.Entries)-1]
-	dm.Dirty = true
-	return nil
+	if idxToSwap == -1 {
+		log.Printf("[DEBUG] SwapRemove: Path '%s' not found.", path)
+		return fmt.Errorf("directory not found for swap-removal: %s", path)
+	}
+	
+	// Now perform the O(1) removal part using the found index
+	lastIdx := len(dm.Entries) - 1
+	if idxToSwap <= lastIdx {
+		dm.Entries[idxToSwap], dm.Entries[lastIdx] = dm.Entries[lastIdx], dm.Entries[idxToSwap]
+		dm.Entries = dm.Entries[:lastIdx]
+		dm.Dirty = true
+		log.Printf("[DEBUG] SwapRemove: Path '%s' (index %d) removed, saving.", path, idxToSwap)
+		return dm.saveInternal()
+	}
+	// Should not happen if idxToSwap was valid and list not empty
+	return fmt.Errorf("SwapRemove: inconsistency for path %s", path)
 }
 
 func quickSort(arr []*Directory, low, high int) {

--- a/test_atomicdb/store_atomic_test.go
+++ b/test_atomicdb/store_atomic_test.go
@@ -1,72 +1,189 @@
 package test_atomicdb
 
 import (
+	"fmt"
 	"os"
-	"testing"
 	"path/filepath"
+	"sync"
+	"testing"
+	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/atliod/gozelle/internal/db"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAtomicSave_NoCorruptionOnInterruption(t *testing.T) {
+func TestAtomicSave_TempFileCleanup(t *testing.T) {
 	dir := t.TempDir()
 	dbFile := filepath.Join(dir, "db.gob")
 	dm, err := db.NewDirectoryManagerWithPath(dbFile)
 	require.NoError(t, err)
 
-	// Add an entry and save
-	dm.Add("/test/dir1")
-	dm.Save()
-	before, err := os.ReadFile(dbFile)
+	// Add entry and save
+	err = dm.Add("/test/dir1")
 	require.NoError(t, err)
-	require.NotEmpty(t, before)
+	err = dm.Save()
+	require.NoError(t, err)
 
-	// Simulate interruption: write partial data to temp file, then crash
+	// Verify temp file doesn't exist after successful save
 	tempFile := dbFile + ".tmp"
-	partial := before[:len(before)/2]
-	err = os.WriteFile(tempFile, partial, 0644)
+	_, err = os.Stat(tempFile)
+	require.True(t, os.IsNotExist(err), "Temp file should be cleaned up after successful save")
+
+	// Verify main file exists and is valid
+	_, err = os.Stat(dbFile)
 	require.NoError(t, err)
 
-	// Now call Save again (should atomically replace with full data)
-	dm.Add("/test/dir2")
-	dm.Save()
-	after, err := os.ReadFile(dbFile)
-	require.NoError(t, err)
-	require.NotEmpty(t, after)
-	// Should not be equal to partial, should be valid gob
-	require.NotEqual(t, partial, after)
-
-	// Try to decode
+	// Verify we can reload the data
 	dm2, err := db.NewDirectoryManagerWithPath(dbFile)
 	require.NoError(t, err)
 	entries, err := dm2.All()
 	require.NoError(t, err)
-	require.Len(t, entries, 2)
+	require.Len(t, entries, 1)
+	require.Equal(t, "/test/dir1", entries[0].Path)
 }
 
-func TestAtomicSave_ConcurrentSaves(t *testing.T) {
+func TestAtomicSave_PreservesOriginalOnTempFileFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	// Use a subdirectory for the DB file
+	dbDir := filepath.Join(dir, "dbdir")
+	err := os.Mkdir(dbDir, 0755)
+	require.NoError(t, err)
+	dbFile := filepath.Join(dbDir, "db.gob")
+	dm, err := db.NewDirectoryManagerWithPath(dbFile)
+	require.NoError(t, err)
+
+	// Create initial valid state
+	err = dm.Add("/test/dir1")
+	require.NoError(t, err)
+	err = dm.Save()
+	require.NoError(t, err)
+
+	// Verify initial state
+	originalData, err := os.ReadFile(dbFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, originalData)
+
+	// Try to add another entry
+	err = dm.Add("/test/dir2")
+	require.NoError(t, err)
+
+	// Make the DB subdirectory read-only to simulate write failure
+	err = os.Chmod(dbDir, 0555) // Read and execute only, no write
+	require.NoError(t, err)
+
+	// Ensure we restore permissions even if test fails
+	defer func() {
+		_ = os.Chmod(dbDir, 0755)
+	}()
+
+	// Try to save again - should fail due to directory permissions
+	err = dm.Save()
+	require.Error(t, err, "Save should fail when temp file can't be created")
+
+	// Restore permissions before reading file
+	err = os.Chmod(dbDir, 0755)
+	require.NoError(t, err)
+
+	// Original file should be unchanged
+	currentData, err := os.ReadFile(dbFile)
+	require.NoError(t, err)
+	if !assert.Equal(t, originalData, currentData, "Original file should be preserved on save failure") {
+		t.Logf("[DEBUG] originalData: %x", originalData)
+		t.Logf("[DEBUG] currentData:  %x", currentData)
+	}
+}
+
+func TestAtomicSave_ConsistentStateUnderConcurrency(t *testing.T) {
 	dir := t.TempDir()
 	dbFile := filepath.Join(dir, "db.gob")
 	dm, err := db.NewDirectoryManagerWithPath(dbFile)
 	require.NoError(t, err)
 
-	N := 10
-	ch := make(chan struct{}, N)
-	for i := 0; i < N; i++ {
-		go func(i int) {
-			_ = dm.Add("/test/dir" + string(rune('A'+i)))
-			_ = dm.Save()
-			ch <- struct{}{}
+	const numGoroutines = 10
+	const opsPerGoroutine = 5
+
+	var wg sync.WaitGroup
+
+	// Launch concurrent goroutines that add entries
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				path := fmt.Sprintf("/test/dir_%d_%d", id, j)
+				err := dm.Add(path)
+				if err != nil {
+					t.Errorf("Add failed: %v", err)
+					return
+				}
+				// Small delay to increase chance of interleaving
+				time.Sleep(time.Millisecond)
+				err = dm.Save()
+				if err != nil {
+					t.Errorf("Save failed: %v", err)
+					return
+				}
+			}
 		}(i)
 	}
-	for i := 0; i < N; i++ {
-		<-ch
-	}
-	// Should not crash or corrupt
+
+	wg.Wait()
+
+	// Verify final state is consistent
 	dm2, err := db.NewDirectoryManagerWithPath(dbFile)
 	require.NoError(t, err)
 	entries, err := dm2.All()
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(entries), 1)
+
+	// Should have exactly numGoroutines * opsPerGoroutine entries
+	require.Len(t, entries, numGoroutines*opsPerGoroutine)
+
+	// Verify all expected paths are present
+	pathSet := make(map[string]bool)
+	for _, entry := range entries {
+		pathSet[entry.Path] = true
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		for j := 0; j < opsPerGoroutine; j++ {
+			expectedPath := fmt.Sprintf("/test/dir_%d_%d", i, j)
+			require.True(t, pathSet[expectedPath], "Expected path %s not found", expectedPath)
+		}
+	}
+}
+
+func TestAtomicSave_FileIntegrityAfterMultipleSaves(t *testing.T) {
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "db.gob")
+	dm, err := db.NewDirectoryManagerWithPath(dbFile)
+	require.NoError(t, err)
+
+	// Perform multiple saves and verify integrity each time
+	for i := 0; i < 20; i++ {
+		path := fmt.Sprintf("/test/dir%d", i)
+		err = dm.Add(path)
+		require.NoError(t, err)
+
+		err = dm.Save()
+		require.NoError(t, err)
+
+		// Verify file can be read and decoded after each save
+		dm2, err := db.NewDirectoryManagerWithPath(dbFile)
+		require.NoError(t, err)
+		entries, err := dm2.All()
+		require.NoError(t, err)
+		require.Len(t, entries, i+1)
+
+		// Verify last added entry exists
+		found := false
+		for _, entry := range entries {
+			if entry.Path == path {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Recently added path %s not found", path)
+	}
 }

--- a/test_atomicdb/store_atomic_test.go
+++ b/test_atomicdb/store_atomic_test.go
@@ -1,0 +1,72 @@
+package test_atomicdb
+
+import (
+	"os"
+	"testing"
+	"path/filepath"
+
+	"github.com/stretchr/testify/require"
+	"github.com/atliod/gozelle/internal/db"
+)
+
+func TestAtomicSave_NoCorruptionOnInterruption(t *testing.T) {
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "db.gob")
+	dm, err := db.NewDirectoryManagerWithPath(dbFile)
+	require.NoError(t, err)
+
+	// Add an entry and save
+	dm.Add("/test/dir1")
+	dm.Save()
+	before, err := os.ReadFile(dbFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, before)
+
+	// Simulate interruption: write partial data to temp file, then crash
+	tempFile := dbFile + ".tmp"
+	partial := before[:len(before)/2]
+	err = os.WriteFile(tempFile, partial, 0644)
+	require.NoError(t, err)
+
+	// Now call Save again (should atomically replace with full data)
+	dm.Add("/test/dir2")
+	dm.Save()
+	after, err := os.ReadFile(dbFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, after)
+	// Should not be equal to partial, should be valid gob
+	require.NotEqual(t, partial, after)
+
+	// Try to decode
+	dm2, err := db.NewDirectoryManagerWithPath(dbFile)
+	require.NoError(t, err)
+	entries, err := dm2.All()
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}
+
+func TestAtomicSave_ConcurrentSaves(t *testing.T) {
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "db.gob")
+	dm, err := db.NewDirectoryManagerWithPath(dbFile)
+	require.NoError(t, err)
+
+	N := 10
+	ch := make(chan struct{}, N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			_ = dm.Add("/test/dir" + string(rune('A'+i)))
+			_ = dm.Save()
+			ch <- struct{}{}
+		}(i)
+	}
+	for i := 0; i < N; i++ {
+		<-ch
+	}
+	// Should not crash or corrupt
+	dm2, err := db.NewDirectoryManagerWithPath(dbFile)
+	require.NoError(t, err)
+	entries, err := dm2.All()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(entries), 1)
+}


### PR DESCRIPTION
Fixes #1 

This PR shores up our data persistence by:
- Making all database saves atomic (write-then-rename) to prevent corruption on interruption.
- Clarifying `Add` (in-memory) vs `AddAndSave` (disk) behavior.
- Adding a suite of tests for atomic saves, concurrency, and data integrity.

This should make Gozelle much more robust against data loss. Cheers!